### PR TITLE
Feature/bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- touchbundle package supports creation of metric bundles, which are logical groups of metrics
 
 ## [v0.1.0]
 - Updated go.uber.org/fx to 1.17.1

--- a/touchbundle/bundle.go
+++ b/touchbundle/bundle.go
@@ -142,13 +142,14 @@ func Provide(prototype interface{}) fx.Option {
 				factory     = in[0].Interface().(*touchstone.Factory)
 				errValue    = reflect.New(errorType)
 				bundleValue = reflect.New(structType)
+				err         = populate(factory, bundleValue.Elem())
 			)
 
-			errValue.Elem().Set(
-				reflect.ValueOf(
-					populate(factory, bundleValue.Elem()),
-				),
-			)
+			if err != nil {
+				errValue.Elem().Set(
+					reflect.ValueOf(err),
+				)
+			}
 
 			if componentType.Kind() == reflect.Ptr {
 				out[0] = bundleValue

--- a/touchbundle/bundle.go
+++ b/touchbundle/bundle.go
@@ -1,0 +1,165 @@
+/**
+ * Copyright 2022 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package touchbundle
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/xmidt-org/touchstone"
+	"go.uber.org/fx"
+	"go.uber.org/multierr"
+)
+
+// Bundle represents a group of metrics.  A bundle must always be a non-nil pointer to struct.
+type Bundle interface{}
+
+// populate is the common function for filling out a bundle struct.  The supplied reflect.Value
+// must be an addressable, settable struct.
+func populate(factory *touchstone.Factory, bundle reflect.Value) (err error) {
+	for i := 0; i < bundle.NumField(); i++ {
+		f := metricField(bundle.Type().Field(i))
+		if f.skip() {
+			continue
+		}
+
+		opts, labelNames, fieldErr := f.newOpts()
+		err = multierr.Append(err, fieldErr)
+		if opts == nil || fieldErr != nil {
+			continue
+		}
+
+		var metric interface{}
+		if len(labelNames) > 0 {
+			metric, fieldErr = factory.NewVec(opts, labelNames...)
+		} else {
+			metric, fieldErr = factory.New(opts)
+		}
+
+		err = multierr.Append(err, fieldErr)
+		if fieldErr == nil {
+			bundle.Field(i).Set(reflect.ValueOf(metric))
+		}
+	}
+
+	return
+}
+
+// Populate fills out a bundle with metrics created by the given Factory.
+func Populate(f *touchstone.Factory, b Bundle) error {
+	bv := reflect.ValueOf(b)
+	if bv.Kind() == reflect.Ptr && !bv.IsNil() {
+		bv = bv.Elem()
+	}
+
+	if bv.Kind() != reflect.Struct || !bv.CanAddr() {
+		return fmt.Errorf(
+			"'%T' is not a valid bundle.  It must be a non-nil pointer to a struct.",
+			b,
+		)
+	}
+
+	return populate(f, bv)
+}
+
+var (
+	errorType   = reflect.TypeOf((*error)(nil)).Elem()
+	factoryType = reflect.TypeOf((*touchstone.Factory)(nil))
+)
+
+// Provide emits a bundle as an uber/fx component.  The supplied prototype must be
+// either a struct or a pointer to struct.  The returned component will be a new
+// instance of the same type as the prototype.
+//
+// For example:
+//
+//     app := fx.New(
+//         touchbundle.Provide(MyMetrics{}),
+//         fx.Invoke(
+//             func(m MyMetrics) {
+//                 // m's metric fields will have been populated
+//             },
+//         ),
+//     )
+//
+//     app := fx.New(
+//         touchbundle.Provide((*MyStruct)(nil)),
+//         fx.Invoke(
+//             func(m *MyMetrics) {
+//                 // m's metric fields will have been populated
+//                 // m will point to a distinct, new instance of MyMetrics
+//             },
+//         ),
+//     )
+func Provide(prototype interface{}) fx.Option {
+	var (
+		componentType = reflect.TypeOf(prototype)
+		structType    reflect.Type
+	)
+
+	switch {
+	case componentType.Kind() == reflect.Struct:
+		structType = componentType
+
+	case componentType.Kind() == reflect.Ptr && componentType.Elem().Kind() == reflect.Struct:
+		structType = componentType.Elem()
+
+	default:
+		return fx.Error(
+			fmt.Errorf(
+				"'%T' is not a valid bundle prototype.  It is not a struct or pointer to struct.",
+				prototype,
+			),
+		)
+	}
+
+	ctor := reflect.MakeFunc(
+		reflect.FuncOf(
+			[]reflect.Type{
+				factoryType,
+			},
+			[]reflect.Type{componentType, errorType},
+			false,
+		),
+		func(in []reflect.Value) (out []reflect.Value) {
+			out = make([]reflect.Value, 2)
+			var (
+				factory     = in[0].Interface().(*touchstone.Factory)
+				errValue    = reflect.New(errorType)
+				bundleValue = reflect.New(structType)
+			)
+
+			errValue.Elem().Set(
+				reflect.ValueOf(
+					populate(factory, bundleValue.Elem()),
+				),
+			)
+
+			if componentType.Kind() == reflect.Ptr {
+				out[0] = bundleValue
+			} else {
+				out[0] = bundleValue.Elem()
+			}
+
+			out[1] = errValue.Elem()
+			return
+		},
+	)
+
+	return fx.Provide(ctor.Interface())
+}

--- a/touchbundle/bundle_test.go
+++ b/touchbundle/bundle_test.go
@@ -1,0 +1,430 @@
+package touchbundle
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/suite"
+	"github.com/xmidt-org/touchstone"
+	"go.uber.org/zap"
+)
+
+type BundleSuite struct {
+	suite.Suite
+}
+
+func (suite *BundleSuite) newFactory() *touchstone.Factory {
+	cfg := touchstone.Config{
+		Pedantic:                  true,
+		DisableGoCollector:        true,
+		DisableProcessCollector:   true,
+		DisableBuildInfoCollector: true,
+	}
+
+	_, r, err := touchstone.New(cfg)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(r)
+
+	f := touchstone.NewFactory(cfg, zap.L(), r)
+	suite.Require().NotNil(f)
+	return f
+}
+
+func (suite *BundleSuite) successfulPopulate(bundle Bundle) {
+	suite.Require().NoError(
+		Populate(suite.newFactory(), bundle),
+	)
+}
+
+func (suite *BundleSuite) testPopulateNonPointer() {
+	type bundle struct {
+		DoesNotMatter int
+	}
+
+	suite.Error(
+		Populate(suite.newFactory(), bundle{}),
+	)
+}
+
+func (suite *BundleSuite) testPopulateNonStruct() {
+	suite.Error(
+		Populate(suite.newFactory(), 123),
+	)
+}
+
+func (suite *BundleSuite) testPopulateCounters() {
+	type bundle struct {
+		Counter1 prometheus.Counter
+		Counter2 prometheus.Counter     `name:"custom2"`
+		Counter3 *prometheus.CounterVec `labelNames:"foo,bar"`
+		Counter4 *prometheus.CounterVec `name:"custom4" labelNames:"foo,bar"`
+		Ignore1  prometheus.Counter     `touchstone:"-"`
+		Ignore2  *prometheus.CounterVec `touchstone:"-"`
+	}
+
+	var b bundle
+	suite.successfulPopulate(&b)
+	suite.NotNil(b.Counter1, "Counter1 is nil")
+	suite.NotNil(b.Counter2, "Counter2 is nil")
+	suite.NotNil(b.Counter3, "Counter3 is nil")
+	suite.NotNil(b.Counter4, "Counter4 is nil")
+	suite.Nil(b.Ignore1, "Ignore1 is not nil")
+	suite.Nil(b.Ignore2, "Ignore2 is not nil")
+
+	suite.Run("LabelNamesOnNonVector", func() {
+		type bundle struct {
+			C prometheus.Counter `labelNames:"should,cause,an,error"`
+		}
+
+		var b bundle
+		suite.Error(
+			Populate(suite.newFactory(), &b),
+		)
+	})
+
+	suite.Run("MissingLabelNames", func() {
+		type bundle struct {
+			C *prometheus.CounterVec
+		}
+
+		var b bundle
+		suite.Error(
+			Populate(suite.newFactory(), &b),
+		)
+	})
+
+	suite.Run("InvalidTag", func() {
+		type bundle struct {
+			C prometheus.Counter `buckets:"1.0,2.0"` // invalid for a counter
+		}
+
+		var b bundle
+		suite.Error(
+			Populate(suite.newFactory(), &b),
+		)
+	})
+}
+
+func (suite *BundleSuite) testPopulateGauges() {
+	type bundle struct {
+		Gauge1  prometheus.Gauge
+		Gauge2  prometheus.Gauge     `name:"custom2"`
+		Gauge3  *prometheus.GaugeVec `labelNames:"foo,bar"`
+		Gauge4  *prometheus.GaugeVec `name:"custom4" labelNames:"foo,bar"`
+		Ignore1 prometheus.Gauge     `touchstone:"-"`
+		Ignore2 *prometheus.GaugeVec `touchstone:"-"`
+	}
+
+	var b bundle
+	suite.successfulPopulate(&b)
+	suite.NotNil(b.Gauge1, "Gauge1 is nil")
+	suite.NotNil(b.Gauge2, "Gauge2 is nil")
+	suite.NotNil(b.Gauge3, "Gauge3 is nil")
+	suite.NotNil(b.Gauge4, "Gauge4 is nil")
+	suite.Nil(b.Ignore1, "Ignore1 is not nil")
+	suite.Nil(b.Ignore2, "Ignore2 is not nil")
+
+	suite.Run("LabelNamesOnNonVector", func() {
+		type bundle struct {
+			G prometheus.Gauge `labelNames:"should,cause,an,error"`
+		}
+
+		var b bundle
+		suite.Error(
+			Populate(suite.newFactory(), &b),
+		)
+	})
+
+	suite.Run("MissingLabelNames", func() {
+		type bundle struct {
+			G *prometheus.GaugeVec
+		}
+
+		var b bundle
+		suite.Error(
+			Populate(suite.newFactory(), &b),
+		)
+	})
+
+	suite.Run("InvalidTag", func() {
+		type bundle struct {
+			G prometheus.Gauge `buckets:"1.0,2.0"` // invalid for a gauge
+		}
+
+		var b bundle
+		suite.Error(
+			Populate(suite.newFactory(), &b),
+		)
+	})
+}
+
+func (suite *BundleSuite) testPopulateHistograms() {
+	type bundle struct {
+		Histogram1 prometheus.Histogram
+		Histogram2 prometheus.Histogram     `name:"custom2"`
+		Histogram3 *prometheus.HistogramVec `labelNames:"foo,bar" buckets:"0.1, 0.2, 0.5, 1.0"`
+		Histogram4 *prometheus.HistogramVec `name:"custom4" labelNames:"foo,bar"`
+		Ignore1    prometheus.Histogram     `touchstone:"-"`
+		Ignore2    *prometheus.HistogramVec `touchstone:"-"`
+	}
+
+	var b bundle
+	suite.successfulPopulate(&b)
+	suite.NotNil(b.Histogram1, "Histogram1 is nil")
+	suite.NotNil(b.Histogram2, "Histogram2 is nil")
+	suite.NotNil(b.Histogram3, "Histogram3 is nil")
+	suite.NotNil(b.Histogram4, "Histogram4 is nil")
+	suite.Nil(b.Ignore1, "Ignore1 is not nil")
+	suite.Nil(b.Ignore2, "Ignore2 is not nil")
+
+	suite.Run("LabelNamesOnNonVector", func() {
+		type bundle struct {
+			H prometheus.Histogram `labelNames:"should,cause,an,error"`
+		}
+
+		var b bundle
+		suite.Error(
+			Populate(suite.newFactory(), &b),
+		)
+	})
+
+	suite.Run("MissingLabelNames", func() {
+		type bundle struct {
+			H *prometheus.HistogramVec
+		}
+
+		var b bundle
+		suite.Error(
+			Populate(suite.newFactory(), &b),
+		)
+	})
+
+	suite.Run("InvalidBuckets", func() {
+		type bundle struct {
+			H prometheus.Histogram `buckets:"this is not valid"`
+		}
+
+		var b bundle
+		suite.Error(
+			Populate(suite.newFactory(), &b),
+		)
+	})
+
+	suite.Run("AmbiguousTag", func() {
+		type bundle struct {
+			H prometheus.Histogram `buckets:"0.2, 0.5, 1.0, 2.0" bufCap:"123"`
+		}
+
+		var b bundle
+		suite.Error(
+			Populate(suite.newFactory(), &b),
+		)
+	})
+}
+
+func (suite *BundleSuite) testPopulateSummaries() {
+	type bundle struct {
+		Summary1 prometheus.Summary
+		Summary2 prometheus.Summary     `name:"custom2" objectives:"0.2:1.0, 0.5:2.0, 1.0:3.0" ageBuckets:"123" maxAge:"100m" bufCap:"1024"`
+		Summary3 *prometheus.SummaryVec `labelNames:"foo,bar"`
+		Summary4 *prometheus.SummaryVec `name:"custom4" labelNames:"foo,bar"`
+		Ignore1  prometheus.Summary     `touchstone:"-"`
+		Ignore2  *prometheus.SummaryVec `touchstone:"-"`
+	}
+
+	var b bundle
+	suite.successfulPopulate(&b)
+	suite.NotNil(b.Summary1, "Summary1 is nil")
+	suite.NotNil(b.Summary2, "Summary2 is nil")
+	suite.NotNil(b.Summary3, "Summary3 is nil")
+	suite.NotNil(b.Summary4, "Summary4 is nil")
+	suite.Nil(b.Ignore1, "Ignore1 is not nil")
+	suite.Nil(b.Ignore2, "Ignore2 is not nil")
+
+	suite.Run("LabelNamesOnNonVector", func() {
+		type bundle struct {
+			S prometheus.Summary `labelNames:"should,cause,an,error"`
+		}
+
+		var b bundle
+		suite.Error(
+			Populate(suite.newFactory(), &b),
+		)
+	})
+
+	suite.Run("MissingLabelNames", func() {
+		type bundle struct {
+			S *prometheus.SummaryVec
+		}
+
+		var b bundle
+		suite.Error(
+			Populate(suite.newFactory(), &b),
+		)
+	})
+
+	suite.Run("InvalidObjectives", func() {
+		type bundle struct {
+			S prometheus.Summary `objectives:"this is not valid"`
+		}
+
+		var b bundle
+		suite.Error(
+			Populate(suite.newFactory(), &b),
+		)
+	})
+
+	suite.Run("InvalidMagAge", func() {
+		type bundle struct {
+			S prometheus.Summary `maxAge:"this is not valid"`
+		}
+
+		var b bundle
+		suite.Error(
+			Populate(suite.newFactory(), &b),
+		)
+	})
+
+	suite.Run("InvalidAgeBuckets", func() {
+		type bundle struct {
+			S prometheus.Summary `ageBuckets:"this is not valid"`
+		}
+
+		var b bundle
+		suite.Error(
+			Populate(suite.newFactory(), &b),
+		)
+	})
+
+	suite.Run("InvalidBufCap", func() {
+		type bundle struct {
+			S prometheus.Summary `bufCap:"this is not valid"`
+		}
+
+		var b bundle
+		suite.Error(
+			Populate(suite.newFactory(), &b),
+		)
+	})
+}
+
+func (suite *BundleSuite) testPopulateObservers() {
+	type bundle struct {
+		Observer1 prometheus.Observer
+		Observer2 prometheus.Observer `name:"custom2" buckets:"1.0,2.0,3.0"`
+		Observer3 prometheus.Observer `objectives:"1.0:2.0"`
+		Observer4 prometheus.Observer `type:"histogram"`
+		Observer5 prometheus.Observer `type:"summary"`
+		Ignore    prometheus.Observer `touchstone:"-"`
+	}
+
+	var b bundle
+	suite.successfulPopulate(&b)
+	suite.Implements((*prometheus.Histogram)(nil), b.Observer1)
+	suite.Implements((*prometheus.Histogram)(nil), b.Observer2)
+	suite.Implements((*prometheus.Summary)(nil), b.Observer3)
+	suite.Implements((*prometheus.Histogram)(nil), b.Observer4)
+	suite.Implements((*prometheus.Summary)(nil), b.Observer5)
+	suite.Nil(b.Ignore)
+
+	suite.Run("Ambiguous", func() {
+		type bundle struct {
+			O prometheus.Observer `buckets:"1.0, 2.0" bufCap:"123"`
+		}
+
+		var b bundle
+		suite.Error(
+			Populate(suite.newFactory(), &b),
+		)
+	})
+
+	suite.Run("LabelNames", func() {
+		type bundle struct {
+			O prometheus.Observer `labelNames:"not,allowed,for,nonvectors"`
+		}
+
+		var b bundle
+		suite.Error(
+			Populate(suite.newFactory(), &b),
+		)
+	})
+
+	suite.Run("InvalidType", func() {
+		type bundle struct {
+			O prometheus.Observer `type:"what is this?"`
+		}
+
+		var b bundle
+		suite.Error(
+			Populate(suite.newFactory(), &b),
+		)
+	})
+}
+
+func (suite *BundleSuite) testPopulateObserverVecs() {
+	type bundle struct {
+		ObserverVec1 prometheus.ObserverVec `labelNames:"one"`
+		ObserverVec2 prometheus.ObserverVec `name:"custom2" buckets:"1.0,2.0,3.0" labelNames:"foo,bar"`
+		ObserverVec3 prometheus.ObserverVec `objectives:"1.0:2.0" labelNames:"foo"`
+		ObserverVec4 prometheus.ObserverVec `type:"histogram" labelNames:"foo,bar,moo"`
+		ObserverVec5 prometheus.ObserverVec `type:"summary" labelNames:"moo,mar,mab"`
+		Ignore       prometheus.ObserverVec `touchstone:"-"`
+	}
+
+	var b bundle
+	suite.successfulPopulate(&b)
+	suite.IsType((*prometheus.HistogramVec)(nil), b.ObserverVec1)
+	suite.IsType((*prometheus.HistogramVec)(nil), b.ObserverVec2)
+	suite.IsType((*prometheus.SummaryVec)(nil), b.ObserverVec3)
+	suite.IsType((*prometheus.HistogramVec)(nil), b.ObserverVec4)
+	suite.IsType((*prometheus.SummaryVec)(nil), b.ObserverVec5)
+	suite.Nil(b.Ignore)
+
+	suite.Run("Ambiguous", func() {
+		type bundle struct {
+			O prometheus.ObserverVec `buckets:"1.0, 2.0" bufCap:"123"`
+		}
+
+		var b bundle
+		suite.Error(
+			Populate(suite.newFactory(), &b),
+		)
+	})
+
+	suite.Run("MissingLabelNames", func() {
+		type bundle struct {
+			O prometheus.ObserverVec
+		}
+
+		var b bundle
+		suite.Error(
+			Populate(suite.newFactory(), &b),
+		)
+	})
+
+	suite.Run("InvalidType", func() {
+		type bundle struct {
+			O prometheus.ObserverVec `type:"what is this?"`
+		}
+
+		var b bundle
+		suite.Error(
+			Populate(suite.newFactory(), &b),
+		)
+	})
+}
+
+func (suite *BundleSuite) TestPopulate() {
+	suite.Run("NonPointer", suite.testPopulateNonPointer)
+	suite.Run("NonStruct", suite.testPopulateNonStruct)
+	suite.Run("Counters", suite.testPopulateCounters)
+	suite.Run("Gauges", suite.testPopulateGauges)
+	suite.Run("Histograms", suite.testPopulateHistograms)
+	suite.Run("Summaries", suite.testPopulateSummaries)
+	suite.Run("Observers", suite.testPopulateObservers)
+	suite.Run("ObserverVecs", suite.testPopulateObserverVecs)
+}
+
+func TestBundle(t *testing.T) {
+	suite.Run(t, new(BundleSuite))
+}

--- a/touchbundle/doc.go
+++ b/touchbundle/doc.go
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2022 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package touchbundle provides a simple way to create bundles of metrics
+// where the names of the metrics can be optionally tailored but the cardinality,
+// type, etc. cannot.
+//
+// Typical packages expect metrics to be of certain types, e.g. counter or gauge,
+// and to have certain labels.  But a package might wish to allow metric names
+// to be set through configuration or through application code.  This package aims
+// to provide a standard approach to this using structs and struct tags.
+package touchbundle

--- a/touchbundle/metricField.go
+++ b/touchbundle/metricField.go
@@ -1,0 +1,481 @@
+package touchbundle
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/multierr"
+)
+
+const (
+	// TagTouchstone is the struct field tag that controls whether touchstone
+	// ignores the field.  Setting this tag to "-" will cause the field to be
+	// ignored and not populated.
+	//
+	// Use this tag to ignore struct fields that would otherwise be populated,
+	// e.g. if a prometheus.Counter field should be ignored.
+	TagTouchstone = "touchstone"
+
+	// TagNamespace is the struct field tag that specifies the metric namespace.
+	// If absent, the default namespace from the Factory is used.
+	TagNamespace = "namespace"
+
+	// TagSubsystem is the struct field tag that specifies the metric subsystem.
+	// If absent, the default subsystem from the Factory is used.
+	TagSubsystem = "subsystem"
+
+	// TagName is the struct field tag that specifies the metric name.  If absent,
+	// the struct field name is snakecased and used as the metric name, e.g.
+	// a field such as "MyAppCounter *prometheus.CounterVec" has a default name
+	// of "my_app_counter".
+	TagName = "name"
+
+	// TagHelp is the struct field tag that specifies the metric help.  There is
+	// no default for this tag.
+	TagHelp = "help"
+
+	// TagBuckets is the struct field tag specifying the set of histogram buckets.
+	// The format of this tag is a comma-delimited string containing float64 values.
+	// Internal whitespace is allowed.
+	TagBuckets = "buckets"
+
+	// TagObjectives is the struct field tag specifying the set of summary objectives.
+	// The format of this tag is a comma-delimited string containing float64 pairs
+	// separated by semi-colons, e.g. "1.0:2.5, 3.5:6.7".  Internal whitespace
+	// is allowed, e.g. "1.0: 2.5,  3.5: 6.7".
+	TagObjectives = "objectives"
+
+	// TagMaxAge is the struct field tag specifying the summary MaxAge.  This tag's
+	// value must parse as a uint32.
+	TagMaxAge = "maxAge"
+
+	// TagAgeBuckets is the struct field tag specifying the summary AgeBuckets.  This
+	// tag's value must parse as a uint32.
+	TagAgeBuckets = "ageBuckets"
+
+	// TagBufCap is the struct field tag specifying the summary BufCap.  This tag's
+	// value must parse as a uint32.
+	TagBufCap = "bufCap"
+
+	// TagLabelNames specifies the set of label names for the metric.  Only permitted
+	// for vector metrics, e.g. *prometheus.CounterVec.  This type is only valid for
+	// vector types.
+	TagLabelNames = "labelNames"
+
+	// TagType is the struct field tag indicating the type of metric, e.g. histogram
+	// or summary.  This tag is only valid when the struct field type doesn't
+	// uniquely specify a metric, e.g. prometheus.Observer.  If the struct field type
+	// does specify a metric, this tag cannot be supplied or an error is raised.
+	TagType = "type"
+
+	// TypeHistogram is the TagType value indicating that the metric is a histogram
+	// or histogram vector.
+	TypeHistogram = "histogram"
+
+	// TypeSummary is the TagType value indicating that the metric is a summary
+	// or summary vector.
+	TypeSummary = "summary"
+)
+
+// FieldError represents an error while processing a metric field.
+type FieldError struct {
+	// Field is the struct field corresponding to the metric.
+	Field reflect.StructField
+
+	// Cause is the wrapped error that caused this field error.
+	Cause error
+
+	// Message is the error message associated with the field.
+	Message string
+}
+
+func (fe *FieldError) Unwrap() error {
+	return fe.Cause
+}
+
+func (fe *FieldError) Error() string {
+	return fmt.Sprintf(
+		"'%s %s': %s",
+		fe.Field.Name,
+		fe.Field.Type,
+		fe.Message,
+	)
+}
+
+var (
+	counterType      = reflect.TypeOf((*prometheus.Counter)(nil)).Elem()
+	counterVecType   = reflect.TypeOf((*prometheus.CounterVec)(nil))
+	gaugeType        = reflect.TypeOf((*prometheus.Gauge)(nil)).Elem()
+	gaugeVecType     = reflect.TypeOf((*prometheus.GaugeVec)(nil))
+	histogramType    = reflect.TypeOf((*prometheus.Histogram)(nil)).Elem()
+	histogramVecType = reflect.TypeOf((*prometheus.HistogramVec)(nil))
+	summaryType      = reflect.TypeOf((*prometheus.Summary)(nil)).Elem()
+	summaryVecType   = reflect.TypeOf((*prometheus.SummaryVec)(nil))
+	observerType     = reflect.TypeOf((*prometheus.Observer)(nil)).Elem()
+	observerVecType  = reflect.TypeOf((*prometheus.ObserverVec)(nil)).Elem()
+
+	histogramTagNames = []string{TagBuckets}
+	summaryTagNames   = []string{TagObjectives, TagMaxAge, TagAgeBuckets, TagBufCap}
+	observerTagNames  = append(
+		append([]string{}, histogramTagNames...),
+		summaryTagNames...,
+	)
+)
+
+// metricField is a type alias for reflect.StructField with functionality
+// around extracting metrics information from code.
+type metricField reflect.StructField
+
+// skip runs standard tests against a struct field to see if touchstone
+// should ignore it.
+func (mf metricField) skip() bool {
+	return len(mf.PkgPath) > 0 ||
+		mf.Anonymous ||
+		mf.Tag.Get(TagTouchstone) == "-"
+}
+
+// name returns the metric name for this field.
+func (mf metricField) name() string {
+	return MetricName(reflect.StructField(mf))
+}
+
+// newCounterOpts constructs a prometheus.CounterOpts from this struct field.
+// The tag names that would never apply to any counter are also checked and,
+// if any are present, this method returns an error.
+func (mf metricField) newCounterOpts() (opts prometheus.CounterOpts, err error) {
+	err = mf.checkTagNotAllowed(err, observerTagNames...)
+	opts = prometheus.CounterOpts{
+		Name:      mf.name(),
+		Help:      mf.help(),
+		Namespace: mf.namespace(),
+		Subsystem: mf.subsystem(),
+	}
+
+	return
+}
+
+// newGaugeOpts constructs a prometheus.GaugeOpts from this struct field.
+// The tag names that would never apply to any gauge are also checked and,
+// if any are present, this method returns an error.
+func (mf metricField) newGaugeOpts() (opts prometheus.GaugeOpts, err error) {
+	err = mf.checkTagNotAllowed(err, observerTagNames...)
+	opts = prometheus.GaugeOpts{
+		Name:      mf.name(),
+		Help:      mf.help(),
+		Namespace: mf.namespace(),
+		Subsystem: mf.subsystem(),
+	}
+
+	return
+}
+
+func (mf metricField) newHistogramOpts() (opts prometheus.HistogramOpts, err error) {
+	opts = prometheus.HistogramOpts{
+		Name:      mf.name(),
+		Help:      mf.help(),
+		Namespace: mf.namespace(),
+		Subsystem: mf.subsystem(),
+	}
+
+	var parseErr error
+	opts.Buckets, parseErr = mf.buckets()
+	err = multierr.Append(err, parseErr)
+
+	return
+}
+
+func (mf metricField) newSummaryOpts() (opts prometheus.SummaryOpts, err error) {
+	opts = prometheus.SummaryOpts{
+		Name:      mf.name(),
+		Help:      mf.help(),
+		Namespace: mf.namespace(),
+		Subsystem: mf.subsystem(),
+	}
+
+	opts.Objectives, err = mf.objectives(err)
+	opts.MaxAge, err = mf.maxAge(err)
+	opts.AgeBuckets, err = mf.ageBuckets(err)
+	opts.BufCap, err = mf.bufCap(err)
+
+	return
+}
+
+func (mf metricField) newObserverOpts() (opts interface{}, err error) {
+	var (
+		metricType        = mf.Tag.Get(TagType)
+		ambiguousTagNames []string
+	)
+
+	switch {
+	case metricType == TypeHistogram:
+		opts, err = mf.newHistogramOpts()
+		ambiguousTagNames = summaryTagNames
+
+	case metricType == TypeSummary:
+		opts, err = mf.newSummaryOpts()
+		ambiguousTagNames = histogramTagNames
+
+	case len(metricType) > 0:
+		err = &FieldError{
+			Field:   reflect.StructField(mf),
+			Message: fmt.Sprintf("'%s' is not a valid observer metric type", metricType),
+		}
+
+	// failing an explicit type, autodetect the type, falling back to a histogram
+
+	case mf.hasAnyTagNames(summaryTagNames...):
+		opts, err = mf.newSummaryOpts()
+		ambiguousTagNames = histogramTagNames
+
+	default:
+		opts, err = mf.newHistogramOpts()
+		ambiguousTagNames = summaryTagNames
+	}
+
+	err = mf.checkTagAmbiguous(err, ambiguousTagNames...)
+	return
+}
+
+// newOpts creates a metric *Opts struct, along with label names, if this
+// field is of a type supported by touchstone.
+func (mf metricField) newOpts() (opts interface{}, labelNames []string, err error) {
+	switch mf.Type {
+	case counterType:
+		opts, err = mf.newCounterOpts()
+		err = mf.checkTagNotAllowed(err, TagType, TagLabelNames)
+
+	case counterVecType:
+		opts, err = mf.newCounterOpts()
+		err = mf.checkTagNotAllowed(err, TagType)
+		labelNames, err = mf.labelNames(err)
+
+	case gaugeType:
+		opts, err = mf.newGaugeOpts()
+		err = mf.checkTagNotAllowed(err, TagType, TagLabelNames)
+
+	case gaugeVecType:
+		opts, err = mf.newGaugeOpts()
+		err = mf.checkTagNotAllowed(err, TagType)
+		labelNames, err = mf.labelNames(err)
+
+	case histogramType:
+		opts, err = mf.newHistogramOpts()
+		err = mf.checkTagNotAllowed(err, TagType, TagLabelNames)
+		err = mf.checkTagNotAllowed(err, summaryTagNames...)
+
+	case histogramVecType:
+		opts, err = mf.newHistogramOpts()
+		err = mf.checkTagNotAllowed(err, TagType)
+		err = mf.checkTagNotAllowed(err, summaryTagNames...)
+		labelNames, err = mf.labelNames(err)
+
+	case summaryType:
+		opts, err = mf.newSummaryOpts()
+		err = mf.checkTagNotAllowed(err, TagType, TagLabelNames)
+		err = mf.checkTagNotAllowed(err, histogramTagNames...)
+
+	case summaryVecType:
+		opts, err = mf.newSummaryOpts()
+		err = mf.checkTagNotAllowed(err, TagType)
+		err = mf.checkTagNotAllowed(err, histogramTagNames...)
+		labelNames, err = mf.labelNames(err)
+
+	case observerType:
+		opts, err = mf.newObserverOpts()
+		err = mf.checkTagNotAllowed(err, TagLabelNames)
+
+	case observerVecType:
+		opts, err = mf.newObserverOpts()
+		labelNames, err = mf.labelNames(err)
+	}
+
+	return
+}
+
+func (mf metricField) help() string {
+	return mf.Tag.Get(TagHelp)
+}
+
+func (mf metricField) namespace() string {
+	return mf.Tag.Get(TagNamespace)
+}
+
+func (mf metricField) subsystem() string {
+	return mf.Tag.Get(TagSubsystem)
+}
+
+// buckets parses any TagBuckets field tag and returns the result.
+func (mf metricField) buckets() (buckets []float64, err error) {
+	tagValue := mf.Tag.Get(TagBuckets)
+	if len(tagValue) == 0 {
+		return
+	}
+
+	tagValues := strings.Split(tagValue, ",")
+	buckets = make([]float64, len(tagValues))
+	for i := 0; i < len(tagValues); i++ {
+		var parseErr error
+		buckets[i], parseErr = strconv.ParseFloat(strings.TrimSpace(tagValues[i]), 64)
+		err = multierr.Append(err, parseErr)
+	}
+
+	return
+}
+
+// objectives parses any TagObjectives field tag and returns the result.
+func (mf metricField) objectives(appendErr error) (objectives map[float64]float64, err error) {
+	err = appendErr
+	tagValue := mf.Tag.Get(TagObjectives)
+	if len(tagValue) == 0 {
+		return
+	}
+
+	tagValues := strings.Split(tagValue, ",")
+	objectives = make(map[float64]float64, len(tagValues))
+	for i := 0; i < len(tagValues); i++ {
+		pair := strings.Split(tagValues[i], ":")
+		if len(pair) != 2 {
+			err = multierr.Append(err,
+				mf.fieldErrorf("Invalid objective entry '%s'", tagValues[i]),
+			)
+
+			continue
+		}
+
+		key, parseErr := strconv.ParseFloat(strings.TrimSpace(pair[0]), 64)
+		err = mf.appendError(err, parseErr)
+
+		value, parseErr := strconv.ParseFloat(strings.TrimSpace(pair[1]), 64)
+		err = mf.appendError(err, parseErr)
+
+		if parseErr == nil {
+			objectives[key] = value
+		}
+	}
+
+	return
+}
+
+// parseUint32 parses a struct field tag that should parse as a uint32.
+func (mf metricField) parseUint32(tagName string) (v uint32, err error) {
+	tagValue := mf.Tag.Get(tagName)
+	if len(tagValue) > 0 {
+		var u64 uint64
+		u64, err = strconv.ParseUint(tagValue, 10, 32)
+		v = uint32(u64)
+	}
+
+	return
+}
+
+// ageBuckets returns the AgeBuckets for this metric.
+func (mf metricField) ageBuckets(appendErr error) (uint32, error) {
+	v, parseErr := mf.parseUint32(TagAgeBuckets)
+	return v, mf.appendError(appendErr, parseErr)
+}
+
+// bufCap returns the BufCap for this metric.
+func (mf metricField) bufCap(appendErr error) (uint32, error) {
+	v, parseErr := mf.parseUint32(TagBufCap)
+	return v, mf.appendError(appendErr, parseErr)
+}
+
+// parseDuration parses a struct field tag that should parse as a time.Duration.
+func (mf metricField) parseDuration(tagName string) (v time.Duration, err error) {
+	tagValue := mf.Tag.Get(tagName)
+	if len(tagValue) > 0 {
+		v, err = time.ParseDuration(tagValue)
+	}
+
+	return
+}
+
+// maxAge returns the MaxAge value for this metric.  If there is no TagMaxAge,
+// this method returns time.Duration(0).
+func (mf metricField) maxAge(appendErr error) (time.Duration, error) {
+	v, err := mf.parseDuration(TagMaxAge)
+	return v, mf.appendError(appendErr, err)
+}
+
+// checkInvalidTagNames examines the field for tags that are considered to be invalid
+// for the metric type in question.  The format string is used to create the error
+// message for each field, and it is expected to take a single %s argument which
+// is the tag name that is invalid.
+func (mf metricField) checkInvalidTagNames(appendErr error, format string, tagNames ...string) (err error) {
+	err = appendErr
+	for _, tagName := range tagNames {
+		if _, ok := mf.Tag.Lookup(tagName); ok {
+			err = multierr.Append(err,
+				&FieldError{
+					Field:   reflect.StructField(mf),
+					Message: fmt.Sprintf(format, tagName),
+				},
+			)
+		}
+	}
+
+	return
+}
+
+func (mf metricField) checkTagNotAllowed(appendErr error, tagNames ...string) error {
+	return mf.checkInvalidTagNames(appendErr, "tag '%s' is not allowed", tagNames...)
+}
+
+func (mf metricField) checkTagAmbiguous(appendErr error, tagNames ...string) error {
+	return mf.checkInvalidTagNames(appendErr, "tag '%s' is ambiguous", tagNames...)
+}
+
+// hasAnyTagNames tests if any of the given tag names are actually present on this field.
+func (mf metricField) hasAnyTagNames(tagNames ...string) (ok bool) {
+	for i := 0; !ok && i < len(tagNames); i++ {
+		_, ok = mf.Tag.Lookup(tagNames[i])
+	}
+
+	return
+}
+
+// labelNames returns the labels described by this field.  An error is raised
+// if there are no label names or the tag wasn't found.
+func (mf metricField) labelNames(appendErr error) (values []string, err error) {
+	err = appendErr
+	v := mf.Tag.Get(TagLabelNames)
+	values = strings.Split(v, ",")
+	for i, ln := range values {
+		values[i] = strings.TrimSpace(ln)
+	}
+
+	if len(values) == 0 {
+		err = multierr.Append(err,
+			mf.fieldErrorf("tag '%s' is required for vector metrics", TagLabelNames),
+		)
+	}
+
+	return
+}
+
+func (mf metricField) fieldErrorf(format string, args ...interface{}) *FieldError {
+	return &FieldError{
+		Field:   reflect.StructField(mf),
+		Message: fmt.Sprintf(format, args...),
+	}
+}
+
+func (mf metricField) wrapError(cause error) *FieldError {
+	return &FieldError{
+		Field:   reflect.StructField(mf),
+		Cause:   cause,
+		Message: cause.Error(),
+	}
+}
+
+func (mf metricField) appendError(appendErr, cause error) error {
+	if cause == nil {
+		return appendErr
+	}
+
+	return multierr.Append(appendErr, mf.wrapError(cause))
+}

--- a/touchbundle/metricField.go
+++ b/touchbundle/metricField.go
@@ -448,9 +448,9 @@ func (mf metricField) labelNames(appendErr error) (values []string, err error) {
 		values[i] = strings.TrimSpace(ln)
 	}
 
-	if len(values) == 0 {
+	if len(values) == 1 && len(values[0]) == 0 {
 		err = multierr.Append(err,
-			mf.fieldErrorf("tag '%s' is required for vector metrics", TagLabelNames),
+			mf.fieldErrorf("tag '%s' is required and cannot be empty for vector metrics", TagLabelNames),
 		)
 	}
 

--- a/touchbundle/metricField_test.go
+++ b/touchbundle/metricField_test.go
@@ -1,0 +1,46 @@
+package touchbundle
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFieldError(t *testing.T) {
+	t.Run("NoCause", func(t *testing.T) {
+		fe := &FieldError{
+			Field: reflect.StructField{
+				Name: "Metric",
+				Type: reflect.TypeOf(123), // doesn't matter
+			},
+			Message: "message",
+		}
+
+		assert := assert.New(t)
+		assert.Nil(fe.Unwrap())
+		assert.Contains(fe.Error(), "Metric")
+		assert.Contains(fe.Error(), "int")
+		assert.Contains(fe.Error(), "message")
+	})
+
+	t.Run("WithCause", func(t *testing.T) {
+		expected := errors.New("expected")
+
+		fe := &FieldError{
+			Field: reflect.StructField{
+				Name: "Metric",
+				Type: reflect.TypeOf(123), // doesn't matter
+			},
+			Cause:   expected,
+			Message: expected.Error(),
+		}
+
+		assert := assert.New(t)
+		assert.ErrorIs(fe, expected)
+		assert.Contains(fe.Error(), "Metric")
+		assert.Contains(fe.Error(), "int")
+		assert.Contains(fe.Error(), "expected")
+	})
+}

--- a/touchbundle/metricName.go
+++ b/touchbundle/metricName.go
@@ -1,0 +1,126 @@
+package touchbundle
+
+import (
+	"reflect"
+	"strings"
+	"unicode"
+)
+
+const snakeCaseSeparator rune = '_'
+
+type snakifier struct {
+	output       strings.Builder
+	parsingUpper bool
+	token        []rune
+}
+
+func (s *snakifier) push(r rune) {
+	switch {
+	case r == snakeCaseSeparator:
+		// separators in the identifiers are preserved if they
+		// aren't leading or trailing
+		s.flush()
+
+	case len(s.token) == 0:
+		s.parsingUpper = unicode.IsUpper(r) || unicode.IsTitle(r)
+		s.token = append(s.token, unicode.ToLower(r))
+
+	case unicode.IsLower(r):
+		if s.parsingUpper {
+			s.parsingUpper = false
+			if len(s.token) > 1 {
+				// this ends a run of capitals
+				// consider the last capital as the start of another token
+				last := s.token[len(s.token)-1]
+				s.token = s.token[0 : len(s.token)-1]
+				s.flush()
+				s.token = append(s.token, last)
+			}
+
+			// if len(token) == 1, it was the start of a token that we are now parsing
+		}
+
+		s.token = append(s.token, r)
+
+	case unicode.IsUpper(r) || unicode.IsTitle(r):
+		if !s.parsingUpper {
+			// this is the start of a new token
+			s.flush()
+			s.parsingUpper = true
+		}
+
+		s.token = append(s.token, unicode.ToLower(r))
+
+	default:
+		// non-letters, non-separators
+		s.token = append(s.token, r)
+	}
+}
+
+func (s *snakifier) flush() {
+	if len(s.token) > 0 {
+		if s.output.Len() > 0 {
+			s.output.WriteRune(snakeCaseSeparator)
+		}
+
+		s.output.WriteString(string(s.token))
+		s.token = s.token[:0]
+	}
+}
+
+func (s *snakifier) String() string {
+	return s.output.String()
+}
+
+// toSnakeCase converts a golang identifier, e.g. a struct field name,
+// into snake case.
+func toSnakeCase(identifier string) string {
+	if len(identifier) == 0 {
+		return identifier
+	}
+
+	s := snakifier{
+		token: make([]rune, 0, 15),
+	}
+
+	for _, r := range identifier {
+		s.push(r)
+	}
+
+	s.flush()
+	return s.String()
+}
+
+// MetricName determines the metric name of a struct field.  A metric name is generated
+// by first looking at the TagName struct field tag, failling back to the snakecase
+// of the field name if that tag is not provide or is empty.  The first occurrence of "*"
+// in the tag will be replaced by the snakecase of the field name, allowing for easy
+// prefixes and suffixes.
+//
+// For example:
+//
+//    type Bundle struct {
+//        // metric name is:  something_count
+//        SomethingCount *prometheus.CounterVec `labelNames:"foo,bar"`
+//
+//        // metric name is: prefix_my_gauge
+//        MyGauge *prometheus.GaugeVec `name:"prefix_*" labelNames:"foo,bar"`
+//
+//        // metric name is: custom_name
+//        AnotherCounter prometheus.Counter `name:"custom_name"`
+//    }
+func MetricName(f reflect.StructField) string {
+	snakeCase := toSnakeCase(f.Name)
+	name := strings.Replace(
+		f.Tag.Get(TagName),
+		"*",
+		snakeCase,
+		1,
+	)
+
+	if len(name) == 0 {
+		name = snakeCase
+	}
+
+	return name
+}

--- a/touchbundle/metricName_test.go
+++ b/touchbundle/metricName_test.go
@@ -1,0 +1,106 @@
+package touchbundle
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToSnakeCase(t *testing.T) {
+	testCases := []struct {
+		identifier string
+		expected   string
+	}{
+		{
+			// empty identifier should result in the empty string
+		},
+		{
+			identifier: "Simple",
+			expected:   "simple",
+		},
+		{
+			identifier: "RequestCount",
+			expected:   "request_count",
+		},
+		{
+			identifier: "RequestURI",
+			expected:   "request_uri",
+		},
+		{
+			identifier: "INITIALCAPS",
+			expected:   "initialcaps",
+		},
+		{
+			identifier: "Preserve_underscore",
+			expected:   "preserve_underscore",
+		},
+		{
+			identifier: "SomethingABCDoit",
+			expected:   "something_abc_doit",
+		},
+		{
+			identifier: "AComplex00Identifier",
+			expected:   "a_complex00_identifier",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.identifier, func(t *testing.T) {
+			assert := assert.New(t)
+			assert.Equal(testCase.expected, toSnakeCase(testCase.identifier))
+		})
+	}
+}
+
+func TestMetricName(t *testing.T) {
+	testCases := []struct {
+		description        string
+		fieldName          string
+		fieldTag           reflect.StructTag
+		expectedMetricName string
+	}{
+		{
+			description:        "simple",
+			fieldName:          "RequestCount",
+			expectedMetricName: "request_count",
+		},
+		{
+			description:        "custom name",
+			fieldName:          "RequestCount",
+			fieldTag:           `name:"custom_name"`,
+			expectedMetricName: "custom_name",
+		},
+		{
+			description:        "prefix",
+			fieldName:          "RequestCount",
+			fieldTag:           `name:"prefix_*"`,
+			expectedMetricName: "prefix_request_count",
+		},
+		{
+			description:        "suffix",
+			fieldName:          "RequestCount",
+			fieldTag:           `name:"*_suffix"`,
+			expectedMetricName: "request_count_suffix",
+		},
+		{
+			description:        "internal",
+			fieldName:          "RequestCount",
+			fieldTag:           `name:"a_*_b"`,
+			expectedMetricName: "a_request_count_b",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			assert.Equal(
+				t,
+				testCase.expectedMetricName,
+				MetricName(reflect.StructField{
+					Name: testCase.fieldName,
+					Tag:  testCase.fieldTag,
+				}),
+			)
+		})
+	}
+}


### PR DESCRIPTION
This is my initial implementation for touchstone bundles.  It provides a way to group metrics together, which is useful when you have a package or an app that wants to create a bunch of metrics that it has control over.  The idea is to remove a lot of repetitive code.

This is an alternative to creating individual metrics and injecting them, e.g. touchstone.Counter, etc.