### PR TITLE
Feature/untyped functions

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -29,3 +29,6 @@ linters-settings:
   errorlint:
     # Report non-wrapping error creation using fmt.Errorf
     errorf: false
+  funlen:
+    lines: 60
+    statements: 60

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 - touchbundle package supports creation of metric bundles, which are logical groups of metrics
+- a version of NewUntypedFunc that allows for flexible function signatures
 
 ## [v0.1.0]
 - Updated go.uber.org/fx to 1.17.1

--- a/factory.go
+++ b/factory.go
@@ -317,18 +317,21 @@ func (f *Factory) NewGaugeVec(o prometheus.GaugeOpts, labelNames ...string) (m *
 }
 
 // NewUntypedFunc creates and registers a new metric backed by the given function.
+// The function must be of a signature supported by the package-level NewUntypedFunc.
 //
 // This method returns an error if the options do not specify a name.  Both namespace
 // and subsystem are defaulted appropriately if not set in the options.
 //
 // See: https://pkg.go.dev/github.com/prometheus/client_golang/prometheus#NewUntypedFunc
-func (f *Factory) NewUntypedFunc(o prometheus.UntypedOpts, fn func() float64) (m prometheus.UntypedFunc, err error) {
+func (f *Factory) NewUntypedFunc(o prometheus.UntypedOpts, fn interface{}) (m prometheus.UntypedFunc, err error) {
 	err = f.checkName(o.Name)
 	if err == nil {
 		ApplyDefaults(&o, f.defaults)
 		f.warnOnNoHelp(o.Name, o.Help)
+		m, err = NewUntypedFunc(o, fn)
+	}
 
-		m = prometheus.NewUntypedFunc(o, fn)
+	if err == nil {
 		err = f.registerer.Register(m)
 	}
 

--- a/untyped.go
+++ b/untyped.go
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2022 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package touchstone
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// NewUntypedFunc is a variant of prometheus.NewUntypedFunc that allows the
+// function to have a more flexible signature.  The supplied function f must accept
+// no arguments and must return exactly (1) value that is any scalar numeric type.
+// The complex types are not supported.
+//
+// In particular, this function is useful when f has the signature func() int.  This
+// is the common case for things like queue depth, length of a data structure, etc.
+//
+// If f is not a function or is a function with a supported signature,
+// this function panics.
+func NewUntypedFunc(opts prometheus.UntypedOpts, f interface{}) prometheus.UntypedFunc {
+	var untyped func() float64
+	switch fn := f.(type) {
+	case func() uint8: // handles byte
+		untyped = func() float64 { return float64(fn()) }
+
+	case func() uint16:
+		untyped = func() float64 { return float64(fn()) }
+
+	case func() uint32:
+		untyped = func() float64 { return float64(fn()) }
+
+	case func() uint64:
+		untyped = func() float64 { return float64(fn()) }
+
+	case func() uint:
+		untyped = func() float64 { return float64(fn()) }
+
+	case func() int8:
+		untyped = func() float64 { return float64(fn()) }
+
+	case func() int16:
+		untyped = func() float64 { return float64(fn()) }
+
+	case func() int32: // handles rune
+		untyped = func() float64 { return float64(fn()) }
+
+	case func() int64:
+		untyped = func() float64 { return float64(fn()) }
+
+	case func() int:
+		untyped = func() float64 { return float64(fn()) }
+
+	case func() float32:
+		untyped = func() float64 { return float64(fn()) }
+
+	case func() float64:
+		untyped = fn
+
+	default:
+		panic(
+			fmt.Errorf(
+				"%T is not a function with the signature func() N, where N is a numeric type",
+				f,
+			),
+		)
+	}
+
+	return prometheus.NewUntypedFunc(opts, untyped)
+}

--- a/untyped.go
+++ b/untyped.go
@@ -31,7 +31,7 @@ import (
 // In particular, this function is useful when f has the signature func() int.  This
 // is the common case for things like queue depth, length of a data structure, etc.
 //
-// If f is not a function or is a function with a supported signature,
+// If f is not a function or is a function with an unsupported signature,
 // an error is returned.
 func NewUntypedFunc(opts prometheus.UntypedOpts, f interface{}) (uf prometheus.UntypedFunc, err error) {
 	var untyped func() float64

--- a/untyped.go
+++ b/untyped.go
@@ -32,8 +32,8 @@ import (
 // is the common case for things like queue depth, length of a data structure, etc.
 //
 // If f is not a function or is a function with a supported signature,
-// this function panics.
-func NewUntypedFunc(opts prometheus.UntypedOpts, f interface{}) prometheus.UntypedFunc {
+// an error is returned.
+func NewUntypedFunc(opts prometheus.UntypedOpts, f interface{}) (uf prometheus.UntypedFunc, err error) {
 	var untyped func() float64
 	switch fn := f.(type) {
 	case func() uint8: // handles byte
@@ -73,13 +73,15 @@ func NewUntypedFunc(opts prometheus.UntypedOpts, f interface{}) prometheus.Untyp
 		untyped = fn
 
 	default:
-		panic(
-			fmt.Errorf(
-				"%T is not a function with the signature func() N, where N is a numeric type",
-				f,
-			),
+		err = fmt.Errorf(
+			"%T is not a function with the signature func() N, where N is a numeric type",
+			f,
 		)
 	}
 
-	return prometheus.NewUntypedFunc(opts, untyped)
+	if err == nil {
+		uf = prometheus.NewUntypedFunc(opts, untyped)
+	}
+
+	return
 }

--- a/untyped_test.go
+++ b/untyped_test.go
@@ -1,0 +1,188 @@
+/**
+ * Copyright 2022 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package touchstone
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/common/expfmt"
+	"github.com/stretchr/testify/suite"
+)
+
+type NewUntypedFuncSuite struct {
+	suite.Suite
+}
+
+func (suite *NewUntypedFuncSuite) newRegistry() *prometheus.Registry {
+	return prometheus.NewPedanticRegistry()
+}
+
+func (suite *NewUntypedFuncSuite) newUntypedOpts() prometheus.UntypedOpts {
+	return prometheus.UntypedOpts{
+		Name: "untyped",
+		Help: "untyped",
+	}
+}
+
+func (suite *NewUntypedFuncSuite) setupExpectation(v float64) io.Reader {
+	registry := suite.newRegistry()
+
+	suite.Require().NoError(
+		registry.Register(
+			prometheus.NewUntypedFunc(
+				suite.newUntypedOpts(),
+				func() float64 { return v },
+			),
+		),
+	)
+
+	families, err := registry.Gather()
+	suite.Require().NoError(err)
+
+	var (
+		output  = new(bytes.Buffer)
+		encoder = expfmt.NewEncoder(output, expfmt.FmtText)
+	)
+
+	for _, fam := range families {
+		suite.Require().NoError(
+			encoder.Encode(fam),
+		)
+	}
+
+	return output
+}
+
+func (suite *NewUntypedFuncSuite) TestSupportedType() {
+	testCases := []struct {
+		description string
+		f           interface{}
+		expected    float64
+	}{
+		{
+			description: "uint8",
+			f:           func() uint8 { return 12 },
+			expected:    12.0,
+		},
+		{
+			description: "uint16",
+			f:           func() uint16 { return 8264 },
+			expected:    8264.0,
+		},
+		{
+			description: "uint32",
+			f:           func() uint32 { return 348 },
+			expected:    348.0,
+		},
+		{
+			description: "uint64",
+			f:           func() uint64 { return 92642 },
+			expected:    92642.0,
+		},
+		{
+			description: "uint",
+			f:           func() uint { return 264 },
+			expected:    264.0,
+		},
+		{
+			description: "int8",
+			f:           func() int8 { return 12 },
+			expected:    12.0,
+		},
+		{
+			description: "int16",
+			f:           func() int16 { return 8264 },
+			expected:    8264.0,
+		},
+		{
+			description: "int32",
+			f:           func() int32 { return 348 },
+			expected:    348.0,
+		},
+		{
+			description: "int64",
+			f:           func() int64 { return 92642 },
+			expected:    92642.0,
+		},
+		{
+			description: "int",
+			f:           func() int { return 264 },
+			expected:    264.0,
+		},
+		{
+			description: "float32",
+			f:           func() float32 { return -462.0 },
+			expected:    -462.0,
+		},
+		{
+			description: "float64",
+			f:           func() float64 { return 1234.0 },
+			expected:    1234.0,
+		},
+	}
+
+	for _, testCase := range testCases {
+		suite.Run(testCase.description, func() {
+			m, err := NewUntypedFunc(suite.newUntypedOpts(), testCase.f)
+			suite.Require().NoError(err)
+
+			actual := suite.newRegistry()
+			suite.Require().NoError(actual.Register(m))
+
+			expected := suite.setupExpectation(testCase.expected)
+			suite.NoError(
+				testutil.GatherAndCompare(actual, expected),
+			)
+		})
+	}
+}
+
+func (suite *NewUntypedFuncSuite) TestUnsupportedType() {
+	testCases := []struct {
+		description string
+		f           interface{}
+	}{
+		{
+			description: "nil",
+			f:           nil,
+		},
+		{
+			description: "not a function",
+			f:           77,
+		},
+		{
+			description: "bad return value",
+			f:           func() string { return "oh no!" },
+		},
+	}
+
+	for _, testCase := range testCases {
+		suite.Run(testCase.description, func() {
+			_, err := NewUntypedFunc(suite.newUntypedOpts(), testCase.f)
+			suite.Error(err)
+		})
+	}
+}
+
+func TestNewUntypedFunc(t *testing.T) {
+	suite.Run(t, new(NewUntypedFuncSuite))
+}

--- a/untyped_test.go
+++ b/untyped_test.go
@@ -63,6 +63,11 @@ func (suite *NewUntypedFuncSuite) setupExpectation(v float64) io.Reader {
 		encoder = expfmt.NewEncoder(output, expfmt.FmtText)
 	)
 
+	if c, ok := encoder.(io.Closer); ok {
+		// the docs say we should always call close, so ...
+		defer c.Close()
+	}
+
 	for _, fam := range families {
 		suite.Require().NoError(
 			encoder.Encode(fam),


### PR DESCRIPTION
Fleshing out support for prometheus' untyped metrics.  The Factory type has already allowed creation of untyped metrics, but this relaxes the constraint on the closure that collects the metric.