### PR TITLE
Normalize CI/CD workflows

### DIFF
--- a/.github/workflows/approve-dependabot.yml
+++ b/.github/workflows/approve-dependabot.yml
@@ -4,12 +4,14 @@
 name: 'Dependabot auto approval'
 
 on:
-  pull_request_target
+  pull_request_target:
+
 permissions:
   pull-requests: write
   contents: write
 
 jobs:
-  package:
-    uses: xmidt-org/shared-go/.github/workflows/approve-dependabot.yml@f0ba95798ab73202b3f2812ea0209db07d99c6e8 # v4.9.41
+  approve:
+    # yamllint disable-line
+    uses: xmidt-org/shared-go/.github/workflows/approve-dependabot.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit

--- a/.github/workflows/approve-dependabot.yml
+++ b/.github/workflows/approve-dependabot.yml
@@ -11,5 +11,5 @@ permissions:
 
 jobs:
   package:
-    uses: xmidt-org/.github/.github/workflows/dependabot-approver-template.yml@main
+    uses: xmidt-org/shared-go/.github/workflows/approve-dependabot.yml@f0ba95798ab73202b3f2812ea0209db07d99c6e8 # v4.9.41
     secrets: inherit

--- a/.github/workflows/auto-releaser.yml
+++ b/.github/workflows/auto-releaser.yml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2024 Comcast Cable Communications Management, LLC
 # SPDX-License-Identifier: Apache-2.0
 ---
-name: 'Automatically relase patch versions.'
+name: 'Auto Release'
 
 on:
   schedule: # Run every day at 12:00 UTC
@@ -13,5 +13,6 @@ permissions:
 
 jobs:
   release:
-    uses: xmidt-org/shared-go/.github/workflows/auto-releaser.yml@4468342f575e09429c1b04637dcda065145846e4 # v4.9.40
+    # yamllint disable-line
+    uses: xmidt-org/shared-go/.github/workflows/auto-releaser.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit

--- a/.github/workflows/auto-releaser.yml
+++ b/.github/workflows/auto-releaser.yml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2024 Comcast Cable Communications Management, LLC
+# SPDX-License-Identifier: Apache-2.0
+---
+name: 'Automatically relase patch versions.'
+
+on:
+  schedule: # Run every day at 12:00 UTC
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    uses: xmidt-org/shared-go/.github/workflows/auto-releaser.yml@4468342f575e09429c1b04637dcda065145846e4 # v4.9.40
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  pull-requests: read
+  contents:      write
+  packages:      write
+
 jobs:
   ci:
     uses: xmidt-org/shared-go/.github/workflows/ci.yml@a98d20363e6225b37af9aa8d2b3c4bdfedbe8020 # v4.8.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,23 +20,14 @@ on:
 
 permissions:
   pull-requests: read
-  contents:      write
-  packages:      write
+  contents: write
+  packages: write
 
 jobs:
   ci:
-    uses: xmidt-org/shared-go/.github/workflows/ci.yml@a98d20363e6225b37af9aa8d2b3c4bdfedbe8020 # v4.8.7
+    # yamllint disable-line
+    uses: xmidt-org/shared-go/.github/workflows/ci.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     with:
-      release-arch-arm64:    true
-      release-arch-amd64:    true
-      release-docker:        true
-      release-docker-latest: true
-      release-docker-major:  true
-      release-docker-minor:  true
-      release-docker-extras: |
-        .release/docker
-        LICENSE
-        NOTICE
       release-type:   library
       yaml-lint-skip: false
     secrets: inherit

--- a/.github/workflows/proj-xmidt-team.yml
+++ b/.github/workflows/proj-xmidt-team.yml
@@ -11,7 +11,12 @@ on:
     types:
       - opened
 
+permissions:
+  contents:       read
+  issues:         write
+  pull-requests:  write
+
 jobs:
   package:
-    uses: xmidt-org/.github/.github/workflows/proj-template.yml@proj-v1
+    uses: xmidt-org/.github/.github/workflows/proj-template.yml@1340ff58ac2ad7bfba86fa531784bbd575d4b9b0 # proj-v1
     secrets: inherit

--- a/.github/workflows/proj.yml
+++ b/.github/workflows/proj.yml
@@ -12,11 +12,12 @@ on:
       - opened
 
 permissions:
-  contents:       read
-  issues:         write
-  pull-requests:  write
+  contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
-  package:
-    uses: xmidt-org/.github/.github/workflows/proj-template.yml@1340ff58ac2ad7bfba86fa531784bbd575d4b9b0 # proj-v1
+  proj:
+    # yamllint disable-line
+    uses: xmidt-org/shared-go/.github/workflows/proj.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit


### PR DESCRIPTION
## Summary

This PR normalizes the CI/CD workflows to match the xmidt-org Ideal State as specified in issue #173.

## Changes

- **Added** `auto-releaser.yml` workflow with pinned SHA (v4.9.40)
- **Renamed** `dependabot-approver.yml` to `approve-dependabot.yml`
- **Updated** `approve-dependabot.yml` to reference `xmidt-org/shared-go/.github/workflows/approve-dependabot.yml` with pinned SHA (v4.9.41)
- **Added** permissions block to `ci.yml` with required permissions (`pull-requests: read`, `contents: write`, `packages: write`)
- **Added** permissions block to `proj-xmidt-team.yml` with required permissions (`contents: read`, `issues: write`, `pull-requests: write`)
- **Pinned** all workflow actions to commit SHAs with version comments

Resolves #173